### PR TITLE
Constify Recorder's _codec member

### DIFF
--- a/src/helpers/Recorder.h
+++ b/src/helpers/Recorder.h
@@ -89,7 +89,7 @@ private:
 
 	// Video context ptrs if available.
 	AVFormatContext * _formatCtx = nullptr;
-	AVCodec * _codec = nullptr;
+	const AVCodec * _codec = nullptr;
 	AVCodecContext * _codecCtx = nullptr;
 	AVStream * _stream = nullptr;
 	AVFrame * _frame = nullptr;


### PR DESCRIPTION
In FFmpeg the avcodec_find_encoder function returns
a const AVCodec object since commit 626535f

This breaks the build for me on ArchLinux.
This simple fix fixes the build, not runtime issues observed.