### PR TITLE
Add 'loop' feature

### DIFF
--- a/src/rendering/State.cpp
+++ b/src/rendering/State.cpp
@@ -182,6 +182,7 @@ void State::defineOptions(){
 	_sharedInfos[s_scroll_speed_key] 		= {Category::PLAYBACK, s_scroll_speed_dsc, Type::FLOAT};
 	_sharedInfos[s_scroll_reverse_key] 		= {Category::PLAYBACK, s_scroll_reverse_dsc, Type::BOOLEAN};
 	_sharedInfos[s_scroll_horizontal_key] 	= {Category::PLAYBACK, s_scroll_horizontal_dsc, Type::BOOLEAN};
+	_sharedInfos[s_loop_key] 				= {Category::PLAYBACK, s_loop_dsc, Type::BOOLEAN};
 
 	// Effects
 	_sharedInfos[s_layers_key] 			= {Category::EFFECTS, s_layers_dsc, Type::OTHER};
@@ -474,6 +475,7 @@ void State::updateOptions(){
 	_boolInfos[s_smooth_key] = &applyAA;
 	_boolInfos[s_scroll_reverse_key] = &reverseScroll;
 	_boolInfos[s_scroll_horizontal_key] = &horizontalScroll;
+	_boolInfos[s_loop_key] = &loop;
 
 	_pathInfos[s_bg_img_path_key] = &background.imagePath;
 	_pathInfos[s_particles_paths_key] = &particles.imagePaths;
@@ -920,6 +922,7 @@ void State::reset(){
 	applyAA = false;
 	reverseScroll = false;
 	horizontalScroll = false;
+	loop = false;
 
 	_filePath = "";
 }

--- a/src/rendering/State.h
+++ b/src/rendering/State.h
@@ -216,6 +216,7 @@ public:
 	bool applyAA;
 	bool reverseScroll;
 	bool horizontalScroll;
+	bool loop;
 
 	std::array<int, 16> layersMap; ///< Location of each layer.
 

--- a/src/rendering/Viewer.cpp
+++ b/src/rendering/Viewer.cpp
@@ -213,6 +213,10 @@ SystemAction Viewer::draw(float currentTime) {
 	// playback is disabled.
 	_timer = _shouldPlay ? (currentTime - _timerStart) : _timer;
 
+	if (_shouldPlay && _state.loop && _timer >= _scene->duration()) {
+		reset();
+	}
+
 	// Render scene and blit, with GUI on top if needed.
 	drawScene(_useTransparency);
 
@@ -555,6 +559,18 @@ SystemAction Viewer::drawGUI(const float currentTime) {
 				ImGui::helpTooltip(s_scroll_reverse_dsc);
 			}
 
+			if(_liveplay){
+				ImGui::BeginDisabled();
+			}
+			ImGui::Checkbox("Loop", &_state.loop);
+			if(_liveplay){
+				ImGui::EndDisabled();
+				if(ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)){
+					ImGui::SetTooltip("Not available in liveplay");
+				}
+			} else {
+				ImGui::helpTooltip(s_loop_dsc);
+			}
 		}
 
 		if(ImGui::CollapsingHeader("Notes##HEADER")){

--- a/src/resources/strings.h
+++ b/src/resources/strings.h
@@ -54,6 +54,9 @@ constexpr const char* s_scroll_reverse_dsc 					= "Notes scroll from bottom to t
 constexpr const char* s_scroll_horizontal_key 				= "scroll-horizontal";
 constexpr const char* s_scroll_horizontal_dsc 				= "Notes scroll from right to left when enabled";
 
+constexpr const char* s_loop_key 							= "loop";
+constexpr const char* s_loop_dsc 							= "Loop playback from start to end";
+
 constexpr const char* s_layers_key 							= "layers";
 constexpr const char* s_layers_dsc 							= "Active layers indices, from background to foreground";
 


### PR DESCRIPTION
This PR adds a new checkbox in the settings menu: **Playback > Loop**

When this setting is enabled, the playback restarts automatically when there are no more notes left in the MIDI file. It is the same as pressing 'Restart (r)' at the end of the track.

This setting has no effect while recording a video.